### PR TITLE
Added fix for db migrations & E2E

### DIFF
--- a/backend/migrations/versions/eb6dda4081ae_add_grant_model.py
+++ b/backend/migrations/versions/eb6dda4081ae_add_grant_model.py
@@ -25,6 +25,8 @@ def upgrade():
         sa.Column("name", sa.String(length=100), nullable=False),
         sa.Column("created_at", sa.DateTime(), nullable=True),
         sa.Column("deadline", sa.DateTime(), nullable=True),
+        sa.Column("description", sa.String(length=1000), nullable=True),
+        sa.Column("custom_fields", sa.JSON(), nullable=True),
         sa.Column("owner_id", sa.Integer(), nullable=False),
         sa.ForeignKeyConstraint(
             ["owner_id"],

--- a/e2e/tests/example_with_fixture.spec.ts
+++ b/e2e/tests/example_with_fixture.spec.ts
@@ -112,6 +112,8 @@ test.describe("Authenticated User Flow", () => {
     await authenticatedPage.getByPlaceholder(/dd\/mm\/yyyy/i).fill(deadline);
     await takeScreenshot(authenticatedPage, testInfo, sequentialScreenshotNames("filled-deadline"));
 
+    await authenticatedPage.locator('textarea').fill('Test description for the grant');
+
     await authenticatedPage
       .getByRole("button", { name: /create grant/i })
       .click();


### PR DESCRIPTION
Two fixes:

  1. Migration (backend/migrations/versions/eb6dda4081ae_add_grant_model.py): Added missing description and
  custom_fields columns to the grant table
  
  2. E2E test (e2e/tests/example_with_fixture.spec.ts): Added description field fill before form submission