### PR TITLE
Add frontend code coverage threshold to CI pipeline-Mirrors the backe…

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -17,6 +17,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  COVERAGE_THRESHOLD: "80"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -99,8 +102,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm run test
+      - name: Run tests with coverage
+        run: npm run test:coverage
 
   build:
     needs:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,5 +10,22 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: "./src/test/setup.ts",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "clover"],
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "src/test/**",
+        "src/**/*.test.{ts,tsx}",
+        "src/**/*.d.ts",
+        "src/vite-env.d.ts",
+      ],
+      thresholds: {
+        statements: 80,
+        branches: 80,
+        functions: 80,
+        lines: 80,
+      },
+    },
   },
 })


### PR DESCRIPTION
Add frontend code coverage threshold to CI

  Summary

  - Configures vitest with v8 coverage provider and 80% thresholds (statements, branches, functions, lines) in
  vite.config.ts
  - Updates frontend-ci.yml to run npm run test:coverage instead of npm run test, mirroring the backend's coverage gate
  - Removes accidentally committed coverage/ build artifacts from git tracking (already in .gitignore)

  Notes

  - Current coverage is below 80% on statements/lines (~75%) and functions (~74%) — pipeline will fail until tests are
  added