### PR TITLE
feat: backend API protection for submitted application immutability (…

### DIFF
--- a/backend/src/nausicass_global_green_initiative_api/api/applications/handlers.py
+++ b/backend/src/nausicass_global_green_initiative_api/api/applications/handlers.py
@@ -194,7 +194,9 @@ def update_application(
             application_id=application_id,
             user_id=user.id,
             user_email=user.email,
-            attempted_changes={k: v for k, v in application_dict.items() if v is not None},
+            attempted_changes={
+                k: v for k, v in application_dict.items() if v is not None
+            },
         )
         raise ApiForbidden()
 

--- a/backend/tests/test_update_application.py
+++ b/backend/tests/test_update_application.py
@@ -351,9 +351,7 @@ def test_non_admin_cannot_delete_application(client, db, admin):
     """Test that a regular user cannot delete an application."""
     application_id = _setup_non_admin_with_application(client)
 
-    response = client.delete(
-        url_for("api.application", application_id=application_id)
-    )
+    response = client.delete(url_for("api.application", application_id=application_id))
 
     assert response.status_code == HTTPStatus.FORBIDDEN
     assert "message" in response.json and response.json["message"] == FORBIDDEN


### PR DESCRIPTION
…#21)

Closes #21

- Replaced `@admin_token_required` with `@token_required` on `update_application` and `delete_application` handlers so that non-admin modification attempts reach the handler body and can be audited
- Non-admin users attempting to PUT or DELETE an application are now blocked via `ApiForbidden` (same 403 response as before) with an audit log entry written before rejection
- Admin PUT requests now record a successful `application_edited` audit log entry including a diff of changed fields (status, feedback, award, field_values)
- Admin DELETE requests now record a `application_edit_blocked` audit log entry for any non-admin attempt, with `{"action": "delete"}` in the attempted changes payload
- Added `_collect_update_changes()` helper to capture non-status field changes for the audit log diff
- Added `AuditService` and `ApiForbidden` imports to `handlers.py`
- Added test: `test_non_admin_cannot_delete_application` — verifies regular users receive 403 on DELETE
- Added test: `test_audit_log_records_blocked_edit_attempt` — verifies blocked PUT writes an `application_edit_blocked` row to the audit log
- Added test: `test_audit_log_records_admin_edit` — verifies successful admin PUT writes an `application_edited` row to the audit log