### PR TITLE
feat: audit log UI and expanded test coverage 

### DIFF
--- a/backend/src/nausicass_global_green_initiative_api/api/audit/dto.py
+++ b/backend/src/nausicass_global_green_initiative_api/api/audit/dto.py
@@ -2,7 +2,7 @@
 
 from flask_restx import Model
 from flask_restx.fields import Boolean, Integer, String
-from flask_restx.inputs import positive
+from flask_restx.inputs import boolean, positive
 from flask_restx.reqparse import RequestParser
 
 audit_log_model = Model(
@@ -38,7 +38,7 @@ audit_list_reqparser.add_argument(
 )
 audit_list_reqparser.add_argument(
     "success",
-    type=bool,
+    type=boolean,
     required=False,
     help="Filter by outcome: true for successful actions, false for failures",
 )

--- a/backend/tests/test_audit_log.py
+++ b/backend/tests/test_audit_log.py
@@ -229,7 +229,7 @@ class TestAuditLogFiltering:
     """Tests for get_filtered_logs model method."""
 
     @pytest.mark.parametrize(
-        "log1,log2,filter_kwargs,expected_field,expected_value",
+        "case",
         [
             (
                 {"action": "grant_created", "entity_type": "grant", "entity_id": 1},
@@ -257,18 +257,9 @@ class TestAuditLogFiltering:
             ),
         ],
     )
-    def test_filter_single_match(
-        self,
-        client,
-        db,
-        test_user,
-        log1,
-        log2,
-        filter_kwargs,
-        expected_field,
-        expected_value,
-    ):
+    def test_filter_single_match(self, client, db, test_user, case):
         """A single-field filter returns exactly the matching log."""
+        log1, log2, filter_kwargs, expected_field, expected_value = case
         AuditLog.log(**log1)
         AuditLog.log(**log2)
 
@@ -373,7 +364,7 @@ class TestAuditApiEndpoints:
         assert "items" in data
 
     @pytest.mark.parametrize(
-        "log1,log2,params,expected_field,expected_value",
+        "case",
         [
             (
                 {"action": "grant_created", "entity_type": "grant", "entity_id": 1},
@@ -418,18 +409,9 @@ class TestAuditApiEndpoints:
             ),
         ],
     )
-    def test_filter_param(
-        self,
-        client,
-        db,
-        admin_user,
-        log1,
-        log2,
-        params,
-        expected_field,
-        expected_value,
-    ):
+    def test_filter_param(self, client, db, admin_user, case):
         """Endpoint returns only the log that matches the given query param."""
+        log1, log2, params, expected_field, expected_value = case
         AuditLog.log(**log1)
         AuditLog.log(**log2)
 

--- a/backend/tests/test_audit_log.py
+++ b/backend/tests/test_audit_log.py
@@ -228,45 +228,47 @@ class TestAuditServiceNewMethods:
 class TestAuditLogFiltering:
     """Tests for get_filtered_logs model method."""
 
-    def test_filter_by_action(self, client, db, test_user):
-        """Only logs matching the requested action are returned."""
-        AuditLog.log(
-            action=AuditAction.GRANT_CREATED.value,
-            entity_type="grant",
-            entity_id=1,
-            user_email=test_user.email,
-        )
-        AuditLog.log(
-            action=AuditAction.GRANT_DELETED.value,
-            entity_type="grant",
-            entity_id=1,
-            user_email=test_user.email,
-        )
+    @pytest.mark.parametrize(
+        "log1,log2,filter_kwargs,expected_field,expected_value",
+        [
+            (
+                {"action": "grant_created", "entity_type": "grant", "entity_id": 1},
+                {"action": "grant_deleted", "entity_type": "grant", "entity_id": 2},
+                {"action": "grant_created"},
+                "action",
+                "grant_created",
+            ),
+            (
+                {
+                    "action": "grant_created",
+                    "entity_type": "grant",
+                    "entity_id": 1,
+                    "success": True,
+                },
+                {
+                    "action": "application_edit_blocked",
+                    "entity_type": "application",
+                    "entity_id": 2,
+                    "success": False,
+                },
+                {"success": False},
+                "success",
+                False,
+            ),
+        ],
+    )
+    def test_filter_single_match(
+        self, client, db, test_user, log1, log2,
+        filter_kwargs, expected_field, expected_value,
+    ):
+        """A single-field filter returns exactly the matching log."""
+        AuditLog.log(**log1)
+        AuditLog.log(**log2)
 
-        results = AuditLog.get_filtered_logs(action="grant_created")
+        results = AuditLog.get_filtered_logs(**filter_kwargs)
 
         assert len(results) == 1
-        assert results[0].action == "grant_created"
-
-    def test_filter_by_success_false(self, client, db, test_user):
-        """Only failed logs are returned when success=False is applied."""
-        AuditLog.log(
-            action=AuditAction.GRANT_CREATED.value,
-            entity_type="grant",
-            entity_id=1,
-            success=True,
-        )
-        AuditLog.log(
-            action=AuditAction.APPLICATION_EDIT_BLOCKED.value,
-            entity_type="application",
-            entity_id=2,
-            success=False,
-        )
-
-        results = AuditLog.get_filtered_logs(success=False)
-
-        assert len(results) == 1
-        assert results[0].success is False
+        assert getattr(results[0], expected_field) == expected_value
 
     def test_filter_by_user_email(self, client, db, test_user, admin_user):
         """Only logs for the specified user email are returned."""
@@ -363,63 +365,63 @@ class TestAuditApiEndpoints:
         assert data["status"] == "success"
         assert "items" in data
 
-    def test_filter_by_action_param(self, client, db, admin_user):
-        """Endpoint returns only logs matching the action query param."""
-        AuditLog.log(
-            action=AuditAction.GRANT_CREATED.value,
-            entity_type="grant",
-            entity_id=1,
-        )
-        AuditLog.log(
-            action=AuditAction.GRANT_DELETED.value,
-            entity_type="grant",
-            entity_id=1,
-        )
+    @pytest.mark.parametrize(
+        "log1,log2,params,expected_field,expected_value",
+        [
+            (
+                {"action": "grant_created", "entity_type": "grant", "entity_id": 1},
+                {"action": "grant_deleted", "entity_type": "grant", "entity_id": 2},
+                "?action=grant_created",
+                "action",
+                "grant_created",
+            ),
+            (
+                {
+                    "action": "grant_created",
+                    "entity_type": "grant",
+                    "entity_id": 1,
+                    "success": True,
+                },
+                {
+                    "action": "application_edit_blocked",
+                    "entity_type": "application",
+                    "entity_id": 2,
+                    "success": False,
+                },
+                "?success=false",
+                "success",
+                False,
+            ),
+            (
+                {
+                    "action": "grant_created",
+                    "entity_type": "grant",
+                    "entity_id": 1,
+                    "user_email": "admin@test.com",
+                },
+                {
+                    "action": "grant_edited",
+                    "entity_type": "grant",
+                    "entity_id": 2,
+                    "user_email": "other@test.com",
+                },
+                "?user_email=admin@test.com",
+                "user_email",
+                "admin@test.com",
+            ),
+        ],
+    )
+    def test_filter_param(
+        self, client, db, admin_user, log1, log2, params, expected_field, expected_value
+    ):
+        """Endpoint returns only the log that matches the given query param."""
+        AuditLog.log(**log1)
+        AuditLog.log(**log2)
 
-        data = _admin_audit_get(client, "?action=grant_created")
+        data = _admin_audit_get(client, params)
 
         assert data["count"] == 1
-        assert data["items"][0]["action"] == "grant_created"
-
-    def test_filter_by_success_false_param(self, client, db, admin_user):
-        """Endpoint returns only failed logs when success=false is passed."""
-        AuditLog.log(
-            action=AuditAction.GRANT_CREATED.value,
-            entity_type="grant",
-            entity_id=1,
-            success=True,
-        )
-        AuditLog.log(
-            action=AuditAction.APPLICATION_EDIT_BLOCKED.value,
-            entity_type="application",
-            entity_id=2,
-            success=False,
-        )
-
-        data = _admin_audit_get(client, "?success=false")
-
-        assert data["count"] == 1
-        assert data["items"][0]["success"] is False
-
-    def test_filter_by_user_email_param(self, client, db, admin_user):
-        """Endpoint returns only logs for the specified user_email."""
-        AuditLog.log(
-            action=AuditAction.GRANT_CREATED.value,
-            entity_type="grant",
-            entity_id=1,
-            user_email="admin@test.com",
-        )
-        AuditLog.log(
-            action=AuditAction.GRANT_EDITED.value,
-            entity_type="grant",
-            entity_id=1,
-            user_email="other@test.com",
-        )
-
-        data = _admin_audit_get(client, "?user_email=admin@test.com")
-
-        assert data["count"] == 1
-        assert data["items"][0]["user_email"] == "admin@test.com"
+        assert data["items"][0][expected_field] == expected_value
 
 
 def _login_and_create_award(client, award_name="eco-grant"):

--- a/backend/tests/test_audit_log.py
+++ b/backend/tests/test_audit_log.py
@@ -258,8 +258,15 @@ class TestAuditLogFiltering:
         ],
     )
     def test_filter_single_match(
-        self, client, db, test_user, log1, log2,
-        filter_kwargs, expected_field, expected_value,
+        self,
+        client,
+        db,
+        test_user,
+        log1,
+        log2,
+        filter_kwargs,
+        expected_field,
+        expected_value,
     ):
         """A single-field filter returns exactly the matching log."""
         AuditLog.log(**log1)
@@ -412,7 +419,15 @@ class TestAuditApiEndpoints:
         ],
     )
     def test_filter_param(
-        self, client, db, admin_user, log1, log2, params, expected_field, expected_value
+        self,
+        client,
+        db,
+        admin_user,
+        log1,
+        log2,
+        params,
+        expected_field,
+        expected_value,
     ):
         """Endpoint returns only the log that matches the given query param."""
         AuditLog.log(**log1)

--- a/backend/tests/test_audit_log.py
+++ b/backend/tests/test_audit_log.py
@@ -331,6 +331,14 @@ class TestAuditLogFiltering:
         assert len(results) == 3
 
 
+def _admin_audit_get(client, params=""):
+    """Login as admin and GET the audit endpoint, returning parsed JSON."""
+    login_user(client, "admin@test.com", "Password123")
+    response = client.get(f"/api/v1/audit{params}")
+    assert response.status_code == 200
+    return response.get_json()
+
+
 class TestAuditApiEndpoints:
     """Tests for audit API endpoints."""
 
@@ -350,12 +358,8 @@ class TestAuditApiEndpoints:
             entity_id=1,
         )
 
-        login_user(client, "admin@test.com", "Password123")
+        data = _admin_audit_get(client)
 
-        response = client.get("/api/v1/audit")
-
-        assert response.status_code == 200
-        data = response.get_json()
         assert data["status"] == "success"
         assert "items" in data
 
@@ -372,11 +376,8 @@ class TestAuditApiEndpoints:
             entity_id=1,
         )
 
-        login_user(client, "admin@test.com", "Password123")
-        response = client.get("/api/v1/audit?action=grant_created")
+        data = _admin_audit_get(client, "?action=grant_created")
 
-        assert response.status_code == 200
-        data = response.get_json()
         assert data["count"] == 1
         assert data["items"][0]["action"] == "grant_created"
 
@@ -395,11 +396,8 @@ class TestAuditApiEndpoints:
             success=False,
         )
 
-        login_user(client, "admin@test.com", "Password123")
-        response = client.get("/api/v1/audit?success=false")
+        data = _admin_audit_get(client, "?success=false")
 
-        assert response.status_code == 200
-        data = response.get_json()
         assert data["count"] == 1
         assert data["items"][0]["success"] is False
 
@@ -418,13 +416,16 @@ class TestAuditApiEndpoints:
             user_email="other@test.com",
         )
 
-        login_user(client, "admin@test.com", "Password123")
-        response = client.get("/api/v1/audit?user_email=admin@test.com")
+        data = _admin_audit_get(client, "?user_email=admin@test.com")
 
-        assert response.status_code == 200
-        data = response.get_json()
         assert data["count"] == 1
         assert data["items"][0]["user_email"] == "admin@test.com"
+
+
+def _login_and_create_award(client, award_name="eco-grant"):
+    """Login as admin and create a named award; returns nothing."""
+    login_user(client, "admin@test.com", "Password123")
+    create_award(client, award_name=award_name, deadline_str=DEFAULT_DEADLINE)
 
 
 class TestAuditAwardHandlerIntegration:
@@ -432,8 +433,7 @@ class TestAuditAwardHandlerIntegration:
 
     def test_create_award_creates_audit_log(self, client, db, admin_user):
         """Creating an award via the API produces an award_created log."""
-        login_user(client, "admin@test.com", "Password123")
-        create_award(client, award_name="eco-grant", deadline_str=DEFAULT_DEADLINE)
+        _login_and_create_award(client)
 
         logs = AuditLog.get_filtered_logs(action="award_created")
 
@@ -443,8 +443,7 @@ class TestAuditAwardHandlerIntegration:
 
     def test_delete_award_creates_audit_log(self, client, db, admin_user):
         """Deleting an award via the API produces an award_deleted log."""
-        login_user(client, "admin@test.com", "Password123")
-        create_award(client, award_name="eco-grant", deadline_str=DEFAULT_DEADLINE)
+        _login_and_create_award(client)
         delete_award(client, "eco-grant")
 
         logs = AuditLog.get_filtered_logs(action="award_deleted")
@@ -454,8 +453,7 @@ class TestAuditAwardHandlerIntegration:
 
     def test_update_award_creates_audit_log(self, client, db, admin_user):
         """Updating an existing award via the API produces an award_edited log."""
-        login_user(client, "admin@test.com", "Password123")
-        create_award(client, award_name="eco-grant", deadline_str=DEFAULT_DEADLINE)
+        _login_and_create_award(client)
         update_award(client, "eco-grant", deadline_str=DEFAULT_DEADLINE)
 
         logs = AuditLog.get_filtered_logs(action="award_edited")

--- a/backend/tests/test_audit_log.py
+++ b/backend/tests/test_audit_log.py
@@ -5,7 +5,14 @@ import pytest
 from nausicass_global_green_initiative_api.models.audit_log import AuditAction, AuditLog
 from nausicass_global_green_initiative_api.models.user import User
 from nausicass_global_green_initiative_api.services.audit_service import AuditService
-from tests.util import login_user, register_user
+from tests.util import (
+    create_award,
+    delete_award,
+    login_user,
+    register_user,
+    update_award,
+    DEFAULT_DEADLINE,
+)
 
 
 @pytest.fixture
@@ -112,6 +119,218 @@ class TestAuditService:
         assert log.success is False
 
 
+class TestAuditServiceNewMethods:
+    """Tests for new AuditService methods added in the audit logging expansion."""
+
+    def test_log_application_created(self, client, db, test_user):
+        """Test logging an application creation via service."""
+        with client.application.test_request_context():
+            log = AuditService.log_application_created(
+                application_id=20,
+                user_id=test_user.id,
+                user_email=test_user.email,
+                details={"grant_name": "Green Future"},
+            )
+
+        assert log.action == "application_created"
+        assert log.entity_type == "application"
+        assert log.entity_id == 20
+        assert log.success is True
+        assert log.is_admin is False
+
+    def test_log_application_deleted(self, client, db, admin_user):
+        """Test logging an application deletion by admin via service."""
+        with client.application.test_request_context():
+            log = AuditService.log_application_deleted(
+                application_id=30,
+                admin_user_id=admin_user.id,
+                admin_email=admin_user.email,
+            )
+
+        assert log.action == "application_deleted"
+        assert log.entity_id == 30
+        assert log.is_admin is True
+        assert log.success is True
+
+    def test_log_login_failed(self, client, db):
+        """Test logging a failed login attempt via service."""
+        with client.application.test_request_context():
+            log = AuditService.log_login_failed(
+                email="hacker@bad.com",
+                reason="Incorrect password",
+            )
+
+        assert log.action == "login_failed"
+        assert log.user_email == "hacker@bad.com"
+        assert log.success is False
+        assert log.failure_reason == "Incorrect password"
+
+    def test_log_unauthorized_access(self, client, db, test_user):
+        """Test logging an unauthorized access attempt via service."""
+        with client.application.test_request_context():
+            log = AuditService.log_unauthorized_access(
+                user_id=test_user.id,
+                user_email=test_user.email,
+                attempted_endpoint="/api/v1/audit",
+            )
+
+        assert log.action == "unauthorized_access"
+        assert log.success is False
+        assert log.failure_reason == "Admin privileges required"
+
+    def test_log_award_created(self, client, db, admin_user):
+        """Test logging an award creation via service."""
+        with client.application.test_request_context():
+            log = AuditService.log_award_created(
+                award_id=5,
+                user_id=admin_user.id,
+                user_email=admin_user.email,
+                is_admin=True,
+                award_name="Excellence Award",
+            )
+
+        assert log.action == "award_created"
+        assert log.entity_type == "award"
+        assert log.entity_id == 5
+        assert log.is_admin is True
+
+    def test_log_award_edited(self, client, db, admin_user):
+        """Test logging an award edit via service."""
+        with client.application.test_request_context():
+            log = AuditService.log_award_edited(
+                award_id=5,
+                user_id=admin_user.id,
+                user_email=admin_user.email,
+                is_admin=True,
+                changes={"deadline": {"from": "2026-05-01", "to": "2026-06-01"}},
+            )
+
+        assert log.action == "award_edited"
+        assert log.entity_type == "award"
+        assert log.success is True
+
+    def test_log_award_deleted(self, client, db, admin_user):
+        """Test logging an award deletion via service."""
+        with client.application.test_request_context():
+            log = AuditService.log_award_deleted(
+                award_id=5,
+                user_id=admin_user.id,
+                user_email=admin_user.email,
+                is_admin=True,
+                award_name="Excellence Award",
+            )
+
+        assert log.action == "award_deleted"
+        assert log.entity_type == "award"
+        assert log.success is True
+
+
+class TestAuditLogFiltering:
+    """Tests for get_filtered_logs model method."""
+
+    def test_filter_by_action(self, client, db, test_user):
+        """Only logs matching the requested action are returned."""
+        AuditLog.log(
+            action=AuditAction.GRANT_CREATED.value,
+            entity_type="grant",
+            entity_id=1,
+            user_email=test_user.email,
+        )
+        AuditLog.log(
+            action=AuditAction.GRANT_DELETED.value,
+            entity_type="grant",
+            entity_id=1,
+            user_email=test_user.email,
+        )
+
+        results = AuditLog.get_filtered_logs(action="grant_created")
+
+        assert len(results) == 1
+        assert results[0].action == "grant_created"
+
+    def test_filter_by_success_false(self, client, db, test_user):
+        """Only failed logs are returned when success=False is applied."""
+        AuditLog.log(
+            action=AuditAction.GRANT_CREATED.value,
+            entity_type="grant",
+            entity_id=1,
+            success=True,
+        )
+        AuditLog.log(
+            action=AuditAction.APPLICATION_EDIT_BLOCKED.value,
+            entity_type="application",
+            entity_id=2,
+            success=False,
+        )
+
+        results = AuditLog.get_filtered_logs(success=False)
+
+        assert len(results) == 1
+        assert results[0].success is False
+
+    def test_filter_by_user_email(self, client, db, test_user, admin_user):
+        """Only logs for the specified user email are returned."""
+        AuditLog.log(
+            action=AuditAction.GRANT_CREATED.value,
+            entity_type="grant",
+            entity_id=1,
+            user_email=test_user.email,
+        )
+        AuditLog.log(
+            action=AuditAction.GRANT_EDITED.value,
+            entity_type="grant",
+            entity_id=1,
+            user_email=admin_user.email,
+        )
+
+        results = AuditLog.get_filtered_logs(user_email=test_user.email)
+
+        assert len(results) == 1
+        assert results[0].user_email == test_user.email
+
+    def test_filter_by_days(self, client, db, test_user):
+        """Logs older than the days window are excluded."""
+        from datetime import datetime, timedelta
+
+        old_log = AuditLog(
+            action=AuditAction.GRANT_CREATED.value,
+            entity_type="grant",
+            entity_id=1,
+            user_email=test_user.email,
+            success=True,
+        )
+        old_log.timestamp = datetime.utcnow() - timedelta(days=10)
+        db.session.add(old_log)
+
+        recent_log = AuditLog.log(
+            action=AuditAction.GRANT_EDITED.value,
+            entity_type="grant",
+            entity_id=1,
+            user_email=test_user.email,
+        )
+        db.session.commit()
+
+        results = AuditLog.get_filtered_logs(days=7)
+
+        ids = [r.id for r in results]
+        assert recent_log.id in ids
+        assert old_log.id not in ids
+
+    def test_no_filters_returns_all(self, client, db, test_user):
+        """Without filters all logs up to the limit are returned."""
+        for i in range(3):
+            AuditLog.log(
+                action=AuditAction.GRANT_CREATED.value,
+                entity_type="grant",
+                entity_id=i,
+                user_email=test_user.email,
+            )
+
+        results = AuditLog.get_filtered_logs()
+
+        assert len(results) == 3
+
+
 class TestAuditApiEndpoints:
     """Tests for audit API endpoints."""
 
@@ -139,3 +358,140 @@ class TestAuditApiEndpoints:
         data = response.get_json()
         assert data["status"] == "success"
         assert "items" in data
+
+    def test_filter_by_action_param(self, client, db, admin_user):
+        """Endpoint returns only logs matching the action query param."""
+        AuditLog.log(
+            action=AuditAction.GRANT_CREATED.value,
+            entity_type="grant",
+            entity_id=1,
+        )
+        AuditLog.log(
+            action=AuditAction.GRANT_DELETED.value,
+            entity_type="grant",
+            entity_id=1,
+        )
+
+        login_user(client, "admin@test.com", "Password123")
+        response = client.get("/api/v1/audit?action=grant_created")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["count"] == 1
+        assert data["items"][0]["action"] == "grant_created"
+
+    def test_filter_by_success_false_param(self, client, db, admin_user):
+        """Endpoint returns only failed logs when success=false is passed."""
+        AuditLog.log(
+            action=AuditAction.GRANT_CREATED.value,
+            entity_type="grant",
+            entity_id=1,
+            success=True,
+        )
+        AuditLog.log(
+            action=AuditAction.APPLICATION_EDIT_BLOCKED.value,
+            entity_type="application",
+            entity_id=2,
+            success=False,
+        )
+
+        login_user(client, "admin@test.com", "Password123")
+        response = client.get("/api/v1/audit?success=false")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["count"] == 1
+        assert data["items"][0]["success"] is False
+
+    def test_filter_by_user_email_param(self, client, db, admin_user):
+        """Endpoint returns only logs for the specified user_email."""
+        AuditLog.log(
+            action=AuditAction.GRANT_CREATED.value,
+            entity_type="grant",
+            entity_id=1,
+            user_email="admin@test.com",
+        )
+        AuditLog.log(
+            action=AuditAction.GRANT_EDITED.value,
+            entity_type="grant",
+            entity_id=1,
+            user_email="other@test.com",
+        )
+
+        login_user(client, "admin@test.com", "Password123")
+        response = client.get("/api/v1/audit?user_email=admin@test.com")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["count"] == 1
+        assert data["items"][0]["user_email"] == "admin@test.com"
+
+
+class TestAuditAwardHandlerIntegration:
+    """Integration tests: award CRUD operations create audit log entries."""
+
+    def test_create_award_creates_audit_log(self, client, db, admin_user):
+        """Creating an award via the API produces an award_created log."""
+        login_user(client, "admin@test.com", "Password123")
+        create_award(client, award_name="eco-grant", deadline_str=DEFAULT_DEADLINE)
+
+        logs = AuditLog.get_filtered_logs(action="award_created")
+
+        assert len(logs) == 1
+        assert logs[0].entity_type == "award"
+        assert logs[0].is_admin is True
+
+    def test_delete_award_creates_audit_log(self, client, db, admin_user):
+        """Deleting an award via the API produces an award_deleted log."""
+        login_user(client, "admin@test.com", "Password123")
+        create_award(client, award_name="eco-grant", deadline_str=DEFAULT_DEADLINE)
+        delete_award(client, "eco-grant")
+
+        logs = AuditLog.get_filtered_logs(action="award_deleted")
+
+        assert len(logs) == 1
+        assert logs[0].entity_type == "award"
+
+    def test_update_award_creates_audit_log(self, client, db, admin_user):
+        """Updating an existing award via the API produces an award_edited log."""
+        login_user(client, "admin@test.com", "Password123")
+        create_award(client, award_name="eco-grant", deadline_str=DEFAULT_DEADLINE)
+        update_award(client, "eco-grant", deadline_str=DEFAULT_DEADLINE)
+
+        logs = AuditLog.get_filtered_logs(action="award_edited")
+
+        assert len(logs) == 1
+        assert logs[0].entity_type == "award"
+
+
+class TestAuditLoginFailureIntegration:
+    """Integration tests: failed logins create login_failed audit log entries."""
+
+    def test_wrong_password_creates_login_failed_log(self, client, db):
+        """A login attempt with a wrong password creates a login_failed entry."""
+        register_user(client, "victim@test.com", "Password123")
+
+        client.post(
+            "/api/v1/auth/login",
+            data="email=victim@test.com&password=WrongPassword1",
+            content_type="application/x-www-form-urlencoded",
+        )
+
+        logs = AuditLog.get_filtered_logs(action="login_failed")
+
+        assert len(logs) == 1
+        assert logs[0].user_email == "victim@test.com"
+        assert logs[0].success is False
+
+    def test_unknown_email_creates_login_failed_log(self, client, db):
+        """A login attempt with an unregistered email creates a login_failed entry."""
+        client.post(
+            "/api/v1/auth/login",
+            data="email=ghost@test.com&password=Password123",
+            content_type="application/x-www-form-urlencoded",
+        )
+
+        logs = AuditLog.get_filtered_logs(action="login_failed")
+
+        assert len(logs) == 1
+        assert logs[0].user_email == "ghost@test.com"

--- a/frontend/src/components/audit/AuditFilters.tsx
+++ b/frontend/src/components/audit/AuditFilters.tsx
@@ -1,26 +1,39 @@
-import { type ChangeEvent, JSX } from "react"
+import { type ChangeEvent, JSX, useState } from "react"
 
-// AuditAction type available in ../../types if needed
+interface FilterState {
+  action: string
+  dateRange: string
+  userEmail: string
+}
+
 interface AuditFiltersProps {
-  onFilterChange: (filters: {
-    action: string
-    dateRange: string
-    userEmail: string
-  }) => void
-  adminEmails: string[] // List of admin emails for dropdown
+  onFilterChange: (filters: FilterState) => void
+  adminEmails: string[]
+}
+
+const DEFAULT_FILTERS: FilterState = {
+  action: "all",
+  dateRange: "7days",
+  userEmail: "all",
 }
 
 export function AuditFilters({
   onFilterChange,
   adminEmails,
 }: AuditFiltersProps): JSX.Element {
-  const handleActionChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    const action = e.target.value
-    onFilterChange({
-      action,
-      dateRange: "7days",
-      userEmail: "all",
-    })
+  const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS)
+
+  const handleChange = (field: keyof FilterState) => (
+    e: ChangeEvent<HTMLSelectElement>,
+  ) => {
+    const updated = { ...filters, [field]: e.target.value }
+    setFilters(updated)
+    onFilterChange(updated)
+  }
+
+  const handleClear = () => {
+    setFilters(DEFAULT_FILTERS)
+    onFilterChange(DEFAULT_FILTERS)
   }
 
   return (
@@ -35,8 +48,8 @@ export function AuditFilters({
             <select
               id="actionFilter"
               className="form-select"
-              onChange={handleActionChange}
-              defaultValue="all"
+              value={filters.action}
+              onChange={handleChange("action")}
             >
               <option value="all">All Actions</option>
               <optgroup label="Grant Actions">
@@ -44,24 +57,23 @@ export function AuditFilters({
                 <option value="grant_edited">Grant Edited</option>
                 <option value="grant_deleted">Grant Deleted</option>
               </optgroup>
-              <optgroup label="Application Actions" disabled>
-                <option value="application_created">
-                  Application Created (Coming Soon)
-                </option>
-                <option value="application_submitted">
-                  Application Submitted (Coming Soon)
-                </option>
-                <option value="application_edited">
-                  Application Edited (Coming Soon)
-                </option>
+              <optgroup label="Award Actions">
+                <option value="award_created">Award Created</option>
+                <option value="award_edited">Award Edited</option>
+                <option value="award_deleted">Award Deleted</option>
               </optgroup>
-              <optgroup label="Security Events" disabled>
-                <option value="application_edit_blocked">
-                  Edit Blocked (Coming Soon)
+              <optgroup label="Application Actions">
+                <option value="application_created">Application Created</option>
+                <option value="application_submitted">
+                  Application Submitted
                 </option>
-                <option value="unauthorized_access">
-                  Unauthorized Access (Coming Soon)
-                </option>
+                <option value="application_edited">Application Edited</option>
+                <option value="application_deleted">Application Deleted</option>
+              </optgroup>
+              <optgroup label="Security Events">
+                <option value="application_edit_blocked">Edit Blocked</option>
+                <option value="login_failed">Login Failed</option>
+                <option value="unauthorized_access">Unauthorized Access</option>
               </optgroup>
             </select>
           </div>
@@ -74,7 +86,8 @@ export function AuditFilters({
             <select
               id="dateRangeFilter"
               className="form-select"
-              defaultValue="7days"
+              value={filters.dateRange}
+              onChange={handleChange("dateRange")}
             >
               <option value="today">Today</option>
               <option value="7days">Last 7 Days</option>
@@ -89,8 +102,13 @@ export function AuditFilters({
             <label htmlFor="userFilter" className="form-label fw-semibold">
               Admin User
             </label>
-            <select id="userFilter" className="form-select" defaultValue="all">
-              <option value="all">All Admins</option>
+            <select
+              id="userFilter"
+              className="form-select"
+              value={filters.userEmail}
+              onChange={handleChange("userEmail")}
+            >
+              <option value="all">All Users</option>
               {adminEmails.map(email => (
                 <option key={email} value={email}>
                   {email}
@@ -101,10 +119,10 @@ export function AuditFilters({
         </div>
 
         <div className="mt-3">
-          <button className="btn btn-outline-secondary btn-sm me-2">
-            Apply Filters
-          </button>
-          <button className="btn btn-outline-danger btn-sm">
+          <button
+            className="btn btn-outline-danger btn-sm"
+            onClick={handleClear}
+          >
             Clear Filters
           </button>
         </div>

--- a/frontend/src/components/audit/AuditFilters.tsx
+++ b/frontend/src/components/audit/AuditFilters.tsx
@@ -23,13 +23,12 @@ export function AuditFilters({
 }: AuditFiltersProps): JSX.Element {
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS)
 
-  const handleChange = (field: keyof FilterState) => (
-    e: ChangeEvent<HTMLSelectElement>,
-  ) => {
-    const updated = { ...filters, [field]: e.target.value }
-    setFilters(updated)
-    onFilterChange(updated)
-  }
+  const handleChange =
+    (field: keyof FilterState) => (e: ChangeEvent<HTMLSelectElement>) => {
+      const updated = { ...filters, [field]: e.target.value }
+      setFilters(updated)
+      onFilterChange(updated)
+    }
 
   const handleClear = () => {
     setFilters(DEFAULT_FILTERS)

--- a/frontend/src/components/audit/AuditStats.tsx
+++ b/frontend/src/components/audit/AuditStats.tsx
@@ -73,9 +73,7 @@ export function AuditStats({ logs, timeRange }: AuditStatsProps): JSX.Element {
             <div className="text-muted small">{timeRange}</div>
             <div className="display-6 my-2">📋 {applicationActions}</div>
             <div className="fw-semibold">Application Actions</div>
-            {applicationActions === 0 && (
-              <div className="text-muted small mt-1">Coming Soon</div>
-            )}
+            <div className="text-muted small mt-1">Created/Submitted/Edited</div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/audit/AuditStats.tsx
+++ b/frontend/src/components/audit/AuditStats.tsx
@@ -73,7 +73,9 @@ export function AuditStats({ logs, timeRange }: AuditStatsProps): JSX.Element {
             <div className="text-muted small">{timeRange}</div>
             <div className="display-6 my-2">📋 {applicationActions}</div>
             <div className="fw-semibold">Application Actions</div>
-            <div className="text-muted small mt-1">Created/Submitted/Edited</div>
+            <div className="text-muted small mt-1">
+              Created/Submitted/Edited
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/audit/AuditTable.tsx
+++ b/frontend/src/components/audit/AuditTable.tsx
@@ -35,7 +35,9 @@ function exportToCsv(logs: AuditLog[]): void {
     "IP Address",
   ]
 
-  const escape = (val: string | number | boolean | null | undefined): string => {
+  const escape = (
+    val: string | number | boolean | null | undefined,
+  ): string => {
     if (val === null || val === undefined) return ""
     const str = String(val)
     return str.includes(",") || str.includes('"') || str.includes("\n")

--- a/frontend/src/components/audit/AuditTable.tsx
+++ b/frontend/src/components/audit/AuditTable.tsx
@@ -1,9 +1,9 @@
 import { JSX } from "react"
 import type { AuditLog } from "../../services/api/audit"
 
-// Helper to parse details JSON string
 interface AuditDetails {
   grant_name?: string
+  award_name?: string
   [key: string]: unknown
 }
 
@@ -21,6 +21,55 @@ interface AuditTableProps {
   onRowClick: (log: AuditLog) => void
 }
 
+function exportToCsv(logs: AuditLog[]): void {
+  const headers = [
+    "ID",
+    "Timestamp",
+    "User",
+    "Is Admin",
+    "Action",
+    "Entity Type",
+    "Entity ID",
+    "Success",
+    "Failure Reason",
+    "IP Address",
+  ]
+
+  const escape = (val: string | number | boolean | null | undefined): string => {
+    if (val === null || val === undefined) return ""
+    const str = String(val)
+    return str.includes(",") || str.includes('"') || str.includes("\n")
+      ? `"${str.replace(/"/g, '""')}"`
+      : str
+  }
+
+  const rows = logs.map(log =>
+    [
+      log.id,
+      log.timestamp,
+      log.user_email,
+      log.is_admin,
+      log.action,
+      log.entity_type,
+      log.entity_id,
+      log.success,
+      log.failure_reason,
+      log.ip_address,
+    ]
+      .map(escape)
+      .join(","),
+  )
+
+  const csv = [headers.join(","), ...rows].join("\n")
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement("a")
+  link.href = url
+  link.download = `audit-logs-${new Date().toISOString().slice(0, 10)}.csv`
+  link.click()
+  URL.revokeObjectURL(url)
+}
+
 export function AuditTable({ logs, onRowClick }: AuditTableProps): JSX.Element {
   const formatTimestamp = (timestamp: string): string => {
     const date = new Date(timestamp)
@@ -34,16 +83,26 @@ export function AuditTable({ logs, onRowClick }: AuditTableProps): JSX.Element {
 
   const getActionBadge = (action: string): JSX.Element => {
     const badges: Record<string, { color: string; label: string }> = {
+      // Grant actions
       grant_created: { color: "success", label: "Created" },
       grant_edited: { color: "warning", label: "Edited" },
       grant_deleted: { color: "danger", label: "Deleted" },
+      // Award actions
+      award_created: { color: "success", label: "Created" },
+      award_edited: { color: "warning", label: "Edited" },
+      award_deleted: { color: "danger", label: "Deleted" },
+      // Application actions
+      application_created: { color: "success", label: "Created" },
       application_submitted: { color: "info", label: "Submitted" },
+      application_edited: { color: "warning", label: "Edited" },
+      application_deleted: { color: "danger", label: "Deleted" },
       application_edit_blocked: { color: "danger", label: "Blocked" },
+      // Security actions
+      login_failed: { color: "danger", label: "Login Failed" },
       unauthorized_access: { color: "danger", label: "Unauthorized" },
     }
 
     const badge = badges[action] || { color: "secondary", label: action }
-
     return <span className={`badge bg-${badge.color}`}>{badge.label}</span>
   }
 
@@ -59,10 +118,12 @@ export function AuditTable({ logs, onRowClick }: AuditTableProps): JSX.Element {
   }
 
   const getEntityDisplay = (log: AuditLog): string => {
-    const entityName =
-      parseDetails(log.details)?.grant_name ||
+    const parsed = parseDetails(log.details)
+    return (
+      parsed?.grant_name ||
+      parsed?.award_name ||
       `${log.entity_type} #${log.entity_id}`
-    return entityName
+    )
   }
 
   if (logs.length === 0) {
@@ -139,11 +200,12 @@ export function AuditTable({ logs, onRowClick }: AuditTableProps): JSX.Element {
           <div className="text-muted">
             Showing {logs.length} of {logs.length} records
           </div>
-          {logs.length > 0 && (
-            <button className="btn btn-outline-secondary btn-sm">
-              Export CSV
-            </button>
-          )}
+          <button
+            className="btn btn-outline-secondary btn-sm"
+            onClick={() => exportToCsv(logs)}
+          >
+            Export CSV
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/AuditLogs.test.tsx
+++ b/frontend/src/pages/AuditLogs.test.tsx
@@ -42,7 +42,7 @@ const mockLogs: AuditLogsResponse = {
   logs: [
     {
       id: 1,
-      timestamp: "2026-03-16T10:00:00Z",
+      timestamp: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
       entity_type: "grant",
       action: "grant_created",
       user_email: "admin@test.com",
@@ -56,7 +56,7 @@ const mockLogs: AuditLogsResponse = {
     },
     {
       id: 2,
-      timestamp: "2026-03-16T11:00:00Z",
+      timestamp: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
       entity_type: "application",
       action: "app_submitted",
       user_email: "user@test.com",
@@ -70,7 +70,7 @@ const mockLogs: AuditLogsResponse = {
     },
     {
       id: 3,
-      timestamp: "2026-03-16T12:00:00Z",
+      timestamp: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
       entity_type: "security",
       action: "login_failed",
       user_email: null,

--- a/frontend/src/pages/AuditLogs.tsx
+++ b/frontend/src/pages/AuditLogs.tsx
@@ -28,7 +28,9 @@ function filterByTab(logs: AuditLog[], tab: AuditTabType): AuditLog[] {
     case "applications":
       return logs.filter(log => log.entity_type === "application")
     case "security":
-      return logs.filter(log => SECURITY_ACTIONS.has(log.action) || !log.success)
+      return logs.filter(
+        log => SECURITY_ACTIONS.has(log.action) || !log.success,
+      )
     case "admins":
       return logs.filter(log => log.is_admin)
     default:
@@ -214,9 +216,9 @@ export function AuditLogs(): JSX.Element {
         <div className="alert alert-warning mb-4" role="alert">
           <strong>🔐 Security Events</strong>
           <p className="mb-0 mt-2">
-            Showing security-relevant events: blocked edit attempts on
-            submitted applications, failed login attempts, and unauthorized
-            access attempts.
+            Showing security-relevant events: blocked edit attempts on submitted
+            applications, failed login attempts, and unauthorized access
+            attempts.
           </p>
         </div>
       )}

--- a/frontend/src/pages/AuditLogs.tsx
+++ b/frontend/src/pages/AuditLogs.tsx
@@ -15,6 +15,54 @@ interface FilterState {
   userEmail: string
 }
 
+const SECURITY_ACTIONS = new Set([
+  "application_edit_blocked",
+  "unauthorized_access",
+  "login_failed",
+])
+
+function filterByTab(logs: AuditLog[], tab: AuditTabType): AuditLog[] {
+  switch (tab) {
+    case "grants":
+      return logs.filter(log => log.entity_type === "grant")
+    case "applications":
+      return logs.filter(log => log.entity_type === "application")
+    case "security":
+      return logs.filter(log => SECURITY_ACTIONS.has(log.action) || !log.success)
+    case "admins":
+      return logs.filter(log => log.is_admin)
+    default:
+      return logs
+  }
+}
+
+function filterByDateRange(logs: AuditLog[], dateRange: string): AuditLog[] {
+  if (dateRange === "all") return logs
+
+  const now = new Date()
+  let cutoff: Date | null = null
+
+  if (dateRange === "today") {
+    cutoff = new Date(now)
+    cutoff.setHours(0, 0, 0, 0)
+  } else {
+    const daysMap: Record<string, number> = {
+      "7days": 7,
+      "30days": 30,
+      "90days": 90,
+    }
+    const days = daysMap[dateRange]
+    if (days !== undefined) {
+      cutoff = new Date(now)
+      cutoff.setDate(cutoff.getDate() - days)
+    }
+  }
+
+  if (!cutoff) return logs
+  const cutoffDate = cutoff
+  return logs.filter(log => new Date(log.timestamp) >= cutoffDate)
+}
+
 export function AuditLogs(): JSX.Element {
   const [activeTab, setActiveTab] = useState<AuditTabType>("grants")
   const [selectedLog, setSelectedLog] = useState<AuditLog | null>(null)
@@ -38,67 +86,14 @@ export function AuditLogs(): JSX.Element {
   const getFilteredLogs = (): AuditLog[] => {
     if (!auditData?.logs) return []
 
-    let filtered = [...auditData.logs]
+    let filtered = filterByTab([...auditData.logs], activeTab)
 
-    // Filter by tab
-    switch (activeTab) {
-      case "grants":
-        filtered = filtered.filter(log => log.entity_type === "grant")
-        break
-      case "applications":
-        filtered = filtered.filter(log => log.entity_type === "application")
-        break
-      case "security":
-        filtered = filtered.filter(
-          log =>
-            log.action === "application_edit_blocked" ||
-            log.action === "unauthorized_access" ||
-            log.action === "login_failed" ||
-            !log.success,
-        )
-        break
-      case "admins":
-        filtered = filtered.filter(log => log.is_admin)
-        break
-      case "all":
-      default:
-        break
-    }
-
-    // Apply action filter
     if (filters.action !== "all") {
       filtered = filtered.filter(log => log.action === filters.action)
     }
 
-    // Apply date range filter
-    if (filters.dateRange !== "all") {
-      const now = new Date()
-      let cutoff: Date | null = null
+    filtered = filterByDateRange(filtered, filters.dateRange)
 
-      if (filters.dateRange === "today") {
-        cutoff = new Date(now)
-        cutoff.setHours(0, 0, 0, 0)
-      } else {
-        const daysMap: Record<string, number> = {
-          "7days": 7,
-          "30days": 30,
-          "90days": 90,
-        }
-        const days = daysMap[filters.dateRange]
-        if (days !== undefined) {
-          cutoff = new Date(now)
-          cutoff.setDate(cutoff.getDate() - days)
-        }
-      }
-
-      if (cutoff) {
-        filtered = filtered.filter(
-          log => new Date(log.timestamp) >= cutoff!,
-        )
-      }
-    }
-
-    // Apply user email filter
     if (filters.userEmail !== "all") {
       filtered = filtered.filter(log => log.user_email === filters.userEmail)
     }
@@ -131,14 +126,7 @@ export function AuditLogs(): JSX.Element {
     if (tab === "applications" || tab === "security") {
       const hasData = auditData?.logs.some(log => {
         if (tab === "applications") return log.entity_type === "application"
-        if (tab === "security")
-          return (
-            log.action === "application_edit_blocked" ||
-            log.action === "unauthorized_access" ||
-            log.action === "login_failed" ||
-            !log.success
-          )
-        return false
+        return SECURITY_ACTIONS.has(log.action) || !log.success
       })
       return !hasData
     }

--- a/frontend/src/pages/AuditLogs.tsx
+++ b/frontend/src/pages/AuditLogs.tsx
@@ -9,16 +9,21 @@ import type { AuditLog } from "../services/api/audit"
 
 type AuditTabType = "all" | "grants" | "applications" | "security" | "admins"
 
+interface FilterState {
+  action: string
+  dateRange: string
+  userEmail: string
+}
+
 export function AuditLogs(): JSX.Element {
   const [activeTab, setActiveTab] = useState<AuditTabType>("grants")
   const [selectedLog, setSelectedLog] = useState<AuditLog | null>(null)
-  const [_filters, _setFilters] = useState({
+  const [filters, setFilters] = useState<FilterState>({
     action: "all",
     dateRange: "7days",
     userEmail: "all",
   })
 
-  // Fetch audit logs
   const {
     data: auditData,
     isLoading,
@@ -26,11 +31,10 @@ export function AuditLogs(): JSX.Element {
     refetch,
   } = useQuery({
     queryKey: ["auditLogs"],
-    queryFn: () => api.audit.getRecentLogs(100),
-    refetchInterval: 30000, // Refresh every 30 seconds
+    queryFn: () => api.audit.getRecentLogs(500),
+    refetchInterval: 30000,
   })
 
-  // Filter logs based on active tab
   const getFilteredLogs = (): AuditLog[] => {
     if (!auditData?.logs) return []
 
@@ -58,22 +62,55 @@ export function AuditLogs(): JSX.Element {
         break
       case "all":
       default:
-        // Show all
         break
     }
 
-    // Additional filters can be applied here based on filters state
+    // Apply action filter
+    if (filters.action !== "all") {
+      filtered = filtered.filter(log => log.action === filters.action)
+    }
+
+    // Apply date range filter
+    if (filters.dateRange !== "all") {
+      const now = new Date()
+      let cutoff: Date | null = null
+
+      if (filters.dateRange === "today") {
+        cutoff = new Date(now)
+        cutoff.setHours(0, 0, 0, 0)
+      } else {
+        const daysMap: Record<string, number> = {
+          "7days": 7,
+          "30days": 30,
+          "90days": 90,
+        }
+        const days = daysMap[filters.dateRange]
+        if (days !== undefined) {
+          cutoff = new Date(now)
+          cutoff.setDate(cutoff.getDate() - days)
+        }
+      }
+
+      if (cutoff) {
+        filtered = filtered.filter(
+          log => new Date(log.timestamp) >= cutoff!,
+        )
+      }
+    }
+
+    // Apply user email filter
+    if (filters.userEmail !== "all") {
+      filtered = filtered.filter(log => log.user_email === filters.userEmail)
+    }
 
     return filtered
   }
 
   const filteredLogs = getFilteredLogs()
 
-  // Get unique admin emails for filter dropdown
-  const adminEmails = Array.from(
+  const allEmails = Array.from(
     new Set(
       auditData?.logs
-        .filter(log => log.is_admin)
         .filter(log => log.user_email !== null)
         .map(log => log.user_email as string) ?? [],
     ),
@@ -91,7 +128,6 @@ export function AuditLogs(): JSX.Element {
   }
 
   const isTabDisabled = (tab: AuditTabType): boolean => {
-    // Disable tabs that don't have data yet
     if (tab === "applications" || tab === "security") {
       const hasData = auditData?.logs.some(log => {
         if (tab === "applications") return log.entity_type === "application"
@@ -99,6 +135,7 @@ export function AuditLogs(): JSX.Element {
           return (
             log.action === "application_edit_blocked" ||
             log.action === "unauthorized_access" ||
+            log.action === "login_failed" ||
             !log.success
           )
         return false
@@ -176,28 +213,29 @@ export function AuditLogs(): JSX.Element {
       )}
 
       {activeTab === "applications" && (
-        <div className="alert alert-warning mb-4" role="alert">
-          <strong>⏳ Coming Soon</strong>
+        <div className="alert alert-info mb-4" role="alert">
+          <strong>📋 Application Activity</strong>
           <p className="mb-0 mt-2">
-            Application audit tracking will be available once the application
-            submission system is implemented by Ronan (Epic #4).
+            Showing all application lifecycle events including creation,
+            submission, admin edits, and deletions.
           </p>
         </div>
       )}
 
       {activeTab === "security" && (
         <div className="alert alert-warning mb-4" role="alert">
-          <strong>⏳ Coming Soon</strong>
+          <strong>🔐 Security Events</strong>
           <p className="mb-0 mt-2">
-            Security event tracking (unauthorized access attempts, blocked
-            edits, failed logins) will be implemented in the next phase.
+            Showing security-relevant events: blocked edit attempts on
+            submitted applications, failed login attempts, and unauthorized
+            access attempts.
           </p>
         </div>
       )}
 
       {/* Filters */}
       {!isTabDisabled(activeTab) && (
-        <AuditFilters onFilterChange={_setFilters} adminEmails={adminEmails} />
+        <AuditFilters onFilterChange={setFilters} adminEmails={allEmails} />
       )}
 
       {/* Loading State */}


### PR DESCRIPTION
## Summary

Implements the frontend audit log UI  and expands backend test coverage for Epic #18 / User Story #22.

### Frontend
- **AuditFilters**: fully controlled with React state; action, date range, and user email selects all wired up; Application Actions and Security Events optgroups enabled; Clear Filters resets all fields
- **AuditTable**: complete badge map for all action types (grant/award/application/security events); CSV export implemented; entity display resolves `award_name` from log details
- **AuditStats**: Application Actions card no longer shows "Coming Soon"
- **AuditLogs page**: filters applied client-side across all params; fetch limit raised to 500; Security Events tab fully enabled

### Tests
- `TestAuditServiceNewMethods`: covers `log_application_created/deleted`, `log_login_failed`, `log_unauthorized_access`, `log_award_created/edited/deleted`
- `TestAuditLogFiltering`: filter by action, success flag, user email, and date range
- `TestAuditApiEndpoints` (extended): query param filtering via the REST endpoint
- `TestAuditAwardHandlerIntegration`: create/update/delete award each emit an audit log entry
- `TestAuditLoginFailureIntegration`: wrong password and unknown email both emit `login_failed`

## Test plan
- [x] All 292 existing backend tests pass
- [x] New test classes run and pass in CI
- [x] Action, date range, and user email filters work correctly in the UI
- [x] Security Events tab shows `login_failed` and `unauthorized_access` entries
- [x] CSV export button downloads a correctly formatted file
